### PR TITLE
dill 0.3.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dill" %}
-{% set version = "0.3.7" %}
+{% set version = "0.3.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: cc1c8b182eb3013e24bd475ff2e9295af86c1a38eb1aff128dac8962a9ce3c03
+  sha256: 3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca
 
 build:
-  skip: true  # [py<37]
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 


### PR DESCRIPTION
dill 0.3.8

**Destination channel:** defaults

### Links

- [Ticket](https://anaconda.atlassian.net/browse/PKG-4312)
- [Upstream repository](https://github.com/uqfoundation/dill)
- [Upstream changelog/diff](https://github.com/uqfoundation/dill/releases/tag/0.3.8)

### Explanation of changes:
- Update version
- Update python version skip
